### PR TITLE
[レビュー]#30 : Doxygenがインストールされていない環境で実行させない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ hrp2/sdk/build.log
 hrp2/sdk/app
 hrp2/sdk/hrp2
 hrp2/sdk/uImage
+doxygen.log
+update_merge_Doxyfiles.log
 
 # for emacs:
 *~

--- a/scripts/updateDoxyfiles.sh
+++ b/scripts/updateDoxyfiles.sh
@@ -3,19 +3,37 @@
 # This script is for updating result of Doxygen.
 
 # Remove old files and directories
-OUTPUT_PATH=hrp2/sdk/html/
-rm -rf ${OUTPUT_PATH}
+OUTPUT_PATH=hrp2/sdk/html
+./scripts/remove_file.sh ${OUTPUT_PATH}
+projectRoot=`pwd`
+logPath=${projectRoot}/hrp2/sdk/doxygen.log
+./scripts/remove_file.sh ${logPath}
 
 # Execute doxygen
-doxygen ./scripts/workspace.Doxyfile
+echo "START: Updating the documents by Doxygen and Graphviz."
+echo ""
 
-echo "$1"
+doxygen ./scripts/workspace.Doxyfile 1>${logPath} 2>&1
+if [ ! -e ${projectRoot}/${OUTPUT_PATH} ]; then
+    echo "ERROR: Perhaps, Doxygen and/or Graphviz are not installed."
+    cd ${projectRoot}
+    exit 2
+fi
+
+./scripts/move_file.sh doxygen.log ${OUTPUT_PATH}/..
+
+echo "END  : Updated the documents."
+echo "       Please open \"hrp2/sdk/html/index.html\" in Web browser."
+echo ""
 
 if [ "${1}" = "Commit" ]
 then
+    echo "$1"
+
     # Commit files
     git add ${OUTPUT_PATH}
     git commit -am "#1 Update doxyfiles"
 fi
 
+cd ${projectRoot}
 exit 0

--- a/scripts/update_merge_Doxyfiles.sh
+++ b/scripts/update_merge_Doxyfiles.sh
@@ -10,6 +10,9 @@ git config --global push.default upstream
 
 # Update docs
 ./scripts/updateDoxyfiles.sh Commit
+if [ $? -ne 0 ]; then
+    exit $2
+fi
 git push origin tasks/1:tasks/1
 
 # Merge branch into `master` from `tasks/1`


### PR DESCRIPTION
# 関連Issue
#30
# 目的

Doxygenがインストールされていない環境で実行させない→意図せず、Doxygenの結果が消されてしまうのを防ぐ
# 実績
## やった事
### 概要

Doxygenの実行に失敗した時は、出力ディレクトリが作成されない。
出力ディレクトリが作成されていなかったら、処理を中断する事で、削除を反映させない。
### 確認した事

`hrp2/sdk/workspace`以下のファイルを変更していない事
### 考慮した事
#### [リスク](https://kotobank.jp/word/%E3%83%AA%E3%82%B9%E3%82%AF-183705)

なし
#### [懸念事項](https://kotobank.jp/word/%E6%87%B8%E5%BF%B5-490895)

なし
